### PR TITLE
New OptimalPacker added

### DIFF
--- a/PackProcessor.js
+++ b/PackProcessor.js
@@ -174,12 +174,11 @@ class PackProcessor {
 
             // duplicate rects if more than 1 combo since the array is mutated in pack()
             let _rects = packerCombos.length > 1 ? rects.map(rect => {
-                return {
-                    ...rect,
-                    frame: {...rect.frame},
-                    spriteSourceSize: {...rect.spriteSourceSize},
-                    sourceSize: {...rect.sourceSize},
-                };
+                return Object.assign({}, rect, {
+                    frame: Object.assign({}, rect.frame),
+                    spriteSourceSize: Object.assign({}, rect.spriteSourceSize),
+                    sourceSize: Object.assign({}, rect.sourceSize)
+                });
             }) : rects;
 
             // duplicate identical if more than 1 combo and fix references to point to the
@@ -187,10 +186,7 @@ class PackProcessor {
             let _identical = packerCombos.length > 1 ? identical.map(rect => {
                 for (let rect2 of _rects) {
                     if (rect.identical.image._base64 == rect2.image._base64) {
-                        return {
-                            ...rect,
-                            identical: rect2
-                        };
+                        return Object.assign({}, rect, { identical: rect2 });
                     }
                 }
             }) : identical;

--- a/PackProcessor.js
+++ b/PackProcessor.js
@@ -1,5 +1,8 @@
 let MaxRectsBinPack = require('./packers/MaxRectsBin');
+let OptimalPacker = require('./packers/OptimalPacker');
+let allPackers = require('./packers').list;
 let Trimmer = require('./utils/Trimmer');
+let TextureRenderer = require('./utils/TextureRenderer');
 
 class PackProcessor {
 
@@ -140,35 +143,95 @@ class PackProcessor {
             identical = res.identical;
         }
 
+        let getAllPackers = () => {
+            let methods = [];
+            for (let packerClass of allPackers) {
+                if (packerClass !== OptimalPacker) {
+                    for (let method in packerClass.methods) {
+                        methods.push({ packerClass, packerMethod: packerClass.methods[method] });
+                    }
+                }
+            }
+            return methods;
+        };
+
         let packerClass = options.packer || MaxRectsBinPack;
         let packerMethod = options.packerMethod || MaxRectsBinPack.methods.BestShortSideFit;
+        let packerCombos = (packerClass === OptimalPacker) ? getAllPackers() : [{ packerClass, packerMethod }];
 
-        let res = [];
+        let optimalRes;
+        let optimalSheets = Infinity;
+        let optimalEfficiency = 0;
 
-        while(rects.length) {
-            let packer = new packerClass(width, height, options.allowRotation);
-            let result = packer.pack(rects, packerMethod);
+        let sourceArea = 0;
+        for (let rect of rects) {
+            sourceArea += rect.sourceSize.w * rect.sourceSize.h;
+        }
 
-            for(let item of result) {
-                item.frame.x += padding + extrude;
-                item.frame.y += padding + extrude;
-                item.frame.w -= padding*2 + extrude*2;
-                item.frame.h -= padding*2 + extrude*2;
+        for (let combo of packerCombos) {
+            let res = [];
+            let sheetArea = 0;
+
+            // duplicate rects if more than 1 combo since the array is mutated in pack()
+            let _rects = packerCombos.length > 1 ? rects.map(rect => {
+                return {
+                    ...rect,
+                    frame: {...rect.frame},
+                    spriteSourceSize: {...rect.spriteSourceSize},
+                    sourceSize: {...rect.sourceSize},
+                };
+            }) : rects;
+
+            // duplicate identical if more than 1 combo and fix references to point to the
+            //  cloned rects since the array is mutated in applyIdentical()
+            let _identical = packerCombos.length > 1 ? identical.map(rect => {
+                for (let rect2 of _rects) {
+                    if (rect.identical.image._base64 == rect2.image._base64) {
+                        return {
+                            ...rect,
+                            identical: rect2
+                        };
+                    }
+                }
+            }) : identical;
+
+            while(_rects.length) {
+                let packer = new combo.packerClass(width, height, options.allowRotation);
+                let result = packer.pack(_rects, combo.packerMethod);
+
+                for(let item of result) {
+                    item.frame.x += padding + extrude;
+                    item.frame.y += padding + extrude;
+                    item.frame.w -= padding*2 + extrude*2;
+                    item.frame.h -= padding*2 + extrude*2;
+                }
+
+                if(options.detectIdentical) {
+                    result = PackProcessor.applyIdentical(result, _identical);
+                }
+
+                res.push(result);
+
+                for(let item of result) {
+                    this.removeRect(_rects, item.name);
+                }
+
+                let { width: sheetWidth, height: sheetHeight } = TextureRenderer.getSize(result, options);
+                sheetArea += sheetWidth * sheetHeight;
             }
 
-            if(options.detectIdentical) {
-                result = PackProcessor.applyIdentical(result, identical);
-            }
+            let sheets = res.length;
+            let efficiency = sourceArea / sheetArea;
 
-            res.push(result);
-
-            for(let item of result) {
-                this.removeRect(rects, item.name);
+            if (sheets < optimalSheets || (sheets === optimalSheets && efficiency > optimalEfficiency)) {
+                optimalRes = res;
+                optimalSheets = sheets;
+                optimalEfficiency = efficiency;
             }
         }
 
         if(onComplete) {
-            onComplete(res);
+            onComplete(optimalRes);
         }
     }
 

--- a/packers/OptimalPacker.js
+++ b/packers/OptimalPacker.js
@@ -1,0 +1,50 @@
+let Packer = require("./Packer");
+
+const METHOD = {
+    Automatic: "Automatic"
+};
+
+class OptimalPacker extends Packer {
+    constructor(width, height, allowRotate=false) {
+        super();
+    }
+
+    pack(data, method) {
+        throw new Error('OptimalPacker is a dummy and cannot be used directly');
+    }
+    
+    static get type() {
+        return "OptimalPacker";
+    }
+
+    static get defaultMethod() {
+        return METHOD.Automatic;
+    }
+
+    static get methods() {
+        return METHOD;
+    }
+
+    static getMethodProps(id='') {
+        switch(id) {
+            case METHOD.Automatic:
+                return {name: "Automatic", description: ""};
+            default:
+                throw Error("Unknown method " + id);
+        }
+    }
+
+    static getMethodByType(type) {
+        type = type.toLowerCase();
+
+        let keys = Object.keys(METHOD);
+
+        for(let name of keys) {
+            if(type === name.toLowerCase()) return METHOD[name];
+        }
+
+        return null;
+    }
+}
+
+module.exports = OptimalPacker;

--- a/packers/index.js
+++ b/packers/index.js
@@ -1,9 +1,11 @@
 let MaxRectsPacker = require("./MaxRectsPacker");
 let MaxRectsBin = require("./MaxRectsBin");
+let OptimalPacker = require("./OptimalPacker");
 
 const list = [
     MaxRectsBin,
-    MaxRectsPacker
+    MaxRectsPacker,
+    OptimalPacker
 ];
 
 function getPackerByType(type) {

--- a/utils/TextureRenderer.js
+++ b/utils/TextureRenderer.js
@@ -13,8 +13,8 @@ class TextureRenderer {
         
         this.render(data, options);
     }
-    
-    render(data, options={}) {
+
+    static getSize(data, options={}) {
         let width = options.width || 0;
         let height = options.height || 0;
         let padding = options.padding || 0;
@@ -34,7 +34,6 @@ class TextureRenderer {
                     h = item.frame.y + item.frame.w;
                 }
 
-
                 if (w > width) {
                     width = w;
                 }
@@ -45,22 +44,27 @@ class TextureRenderer {
 
             width += padding + extrude;
             height += padding + extrude;
-
         }
 
         if (options.powerOfTwo) {
             let sw = Math.round(Math.log(width)/Math.log(2));
             let sh = Math.round(Math.log(height)/Math.log(2));
-			
-			let pw = Math.pow(2, sw);
+
+            let pw = Math.pow(2, sw);
             let ph = Math.pow(2, sh);
-			
-			if(pw < width) pw = Math.pow(2, sw + 1);
-			if(ph < height) ph = Math.pow(2, sh + 1);
-			
-			width = pw;
-			height = ph;
+
+            if(pw < width) pw = Math.pow(2, sw + 1);
+            if(ph < height) ph = Math.pow(2, sh + 1);
+
+            width = pw;
+            height = ph;
         }
+
+        return { width, height };
+    }
+    
+    render(data, options={}) {
+        let { width, height } = TextureRenderer.getSize(data, options);
 
         this.width = width;
         this.height = height;


### PR DESCRIPTION
The new `OptimalPacker` class is basically a dummy that is used to select the "optimal" packing method.

I originally tried to implement the functionality inside the packer but found out that the sheet handling logic was actually outside of the packer and a new instance was generated for each sheet. So in the end I had to modify the `PackProcessor` and use the `OptimalPacker` as a dummy for selecting this packing method.

During profiling with our real-world test data I noticed that the optimal packer and method combination varies wildly based on the source images. Also the performance impact of this brute-force approach is negligible since the image processing takes up a large portion of the total cost.

*Disclaimer: Our data set has a smaller number of large images, I would imagine for people with massive amounts of small images the impact is greater - which is why I've not made this the default packer method.*

This pull request implements #5

ps. There's also some bonus `TextureRenderer` whitespace cleanup that I did while splitting `render` into `getSize` and `render` so that I could re-use the size calculations in the search for the optimal packing.