### PR TITLE
Deterministic output result order for images with the same sizes

### DIFF
--- a/PackProcessor.js
+++ b/PackProcessor.js
@@ -73,7 +73,7 @@ class PackProcessor {
         let alphaThreshold = options.alphaThreshold || 0;
         if(alphaThreshold > 255) alphaThreshold = 255;
 
-        let names = Object.keys(images);
+        let names = Object.keys(images).sort();
         
         for(let key of names) {
             let img = images[key];


### PR DESCRIPTION
sort images names before pushing to rects array
It make sure output file the same.