### PR TITLE
This is my approach to add the feature I requested on #18

### DIFF
--- a/FilesProcessor.js
+++ b/FilesProcessor.js
@@ -21,9 +21,17 @@ class FilesProcessor {
                         });
 
                         if(packResult.length >= res.length) {
+
+                            //if this is a multipack
+                            if (packResult.length > 1)
+                            {
+                                //make an array with all the files generated with the corresponding extension
+                                options.relatedMultiPacks = packResult.map(_item, index => options.textureName + (!options.omitZeroIndex || index > 0 ? "-" + index : "") + "." + options.exporter.fileExt); 
+                            }
+
                             let ix = 0;
                             for(let item of packResult) {
-                                let fName = options.textureName + (packResult.length > 1 ? "-" + ix : "");
+                                let fName = options.textureName + (packResult.length > 1  && (!options.omitZeroIndex || ix > 0) ? "-" + ix : "");
 
                                 FilesProcessor.processPackResultItem(fName, item, options, (files) => {
                                     resFiles = resFiles.concat(files);
@@ -64,7 +72,8 @@ class FilesProcessor {
                     base64Export: options.base64Export,
                     scale: options.scale,
                     appInfo: options.appInfo,
-                    trimMode: options.trimMode
+                    trimMode: options.trimMode,
+                    relatedMultiPacks: options.relatedMultiPacks.filter(filename=>filename.indexOf(fName + "." + options.exporter.fileExt) === -1) //a file doesn't contain itself in the multipack array
                 };
                 
                 files.push({

--- a/FilesProcessor.js
+++ b/FilesProcessor.js
@@ -23,10 +23,13 @@ class FilesProcessor {
                         if(packResult.length >= res.length) {
 
                             //if this is a multipack
-                            if (packResult.length > 1)
-                            {
+                            if (packResult.length > 1) {
                                 //make an array with all the files generated with the corresponding extension
-                                options.relatedMultiPacks = packResult.map(_item, index => options.textureName + (!options.omitZeroIndex || index > 0 ? "-" + index : "") + "." + options.exporter.fileExt); 
+                                options.relatedMultiPacks = packResult.map((_item, index) => ({name:options.textureName + (!options.omitZeroIndex || index > 0 ? "-" + index : "") + "." + options.exporter.fileExt}));
+                            }
+                            else {
+                                //without this I crash when I try to filter out the result
+                                options.relatedMultiPacks = [];
                             }
 
                             let ix = 0;
@@ -73,7 +76,7 @@ class FilesProcessor {
                     scale: options.scale,
                     appInfo: options.appInfo,
                     trimMode: options.trimMode,
-                    relatedMultiPacks: options.relatedMultiPacks.filter(filename=>filename.indexOf(fName + "." + options.exporter.fileExt) === -1) //a file doesn't contain itself in the multipack array
+                    relatedMultiPacks: options.relatedMultiPacks.filter(fileObj => fileObj.name.indexOf(fName + "." + options.exporter.fileExt) === -1) //a file doesn't contain itself in the multipack array
                 };
                 
                 files.push({

--- a/exporters/JsonHash.mst
+++ b/exporters/JsonHash.mst
@@ -36,12 +36,13 @@
       "w": {{config.imageWidth}},
       "h": {{config.imageHeight}}
     },
+    {{#config.isMultiPack}}
     "relatedMultiPacks":[
       {{#config.relatedMultiPacks}}
-        {{.}}
-      {{^last}},{{/last}}
+        "{{name}}"{{^last}},{{/last}}
       {{/config.relatedMultiPacks}}
     ],
+    {{/config.isMultiPack}}
     "scale": {{config.scale}}
   }
 }

--- a/exporters/JsonHash.mst
+++ b/exporters/JsonHash.mst
@@ -36,6 +36,12 @@
       "w": {{config.imageWidth}},
       "h": {{config.imageHeight}}
     },
+    "relatedMultiPacks":[
+      {{#config.relatedMultiPacks}}
+        {{.}}
+      {{^last}},{{/last}}
+      {{/config.relatedMultiPacks}}
+    ],
     "scale": {{config.scale}}
   }
 }

--- a/exporters/index.js
+++ b/exporters/index.js
@@ -131,8 +131,10 @@ function prepareData(data, options) {
     }
 
     if(opt.relatedMultiPacks.length) {
-        opt.relatedMultiPacks[0].first = true;
-        opt.relatedMultiPacks[opt.relatedMultiPacks.length-1].last = true;
+        for (let i = 0; i < opt.relatedMultiPacks.length; i++) {
+            opt.relatedMultiPacks[i].first = i == 0;
+            opt.relatedMultiPacks[i].last = i == opt.relatedMultiPacks.length - 1;
+        }
         opt.isMultiPack = true;
     }
 

--- a/exporters/index.js
+++ b/exporters/index.js
@@ -130,6 +130,12 @@ function prepareData(data, options) {
         ret[ret.length-1].last = true;
     }
 
+    if(opt.relatedMultiPacks.length) {
+        opt.relatedMultiPacks[0].first = true;
+        opt.relatedMultiPacks[opt.relatedMultiPacks.length-1].last = true;
+        opt.isMultiPack = true;
+    }
+
     return {rects: ret, config: opt};
 }
 

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ function packAsync(images, options) {
     options.tinify = options.tinify === undefined ? false : options.tinify;
     options.tinifyKey = options.tinifyKey === undefined ? "" : options.tinifyKey;
     options.filter = options.filter === undefined ? "none" : options.filter;
+    options.omitZeroIndex = options.omitZeroIndex === undefined ? false : options.omitZeroIndex;
 
     if(!options.packer) options.packer = "MaxRectsBin";
     if(!options.exporter) options.exporter = "JsonHash";


### PR DESCRIPTION
I requested a feature on #18 and after seeing the source I think this should add what I wanted however I am not really experienced with mustache and (since I am a bit of a noob with js) I couldn't find how to test tis solution. However I think the code is quite simple.

I did 3 things:

- on index.js I added a flag to allow for the `-0` in the name of the output to be dropped (making the output look like `atlas.json`, `atlas-1.json`, `atlas-2.json`...) This allows for seamless fallback in case you are building with a pipeline like webpack. (By default this flag is false to avoid breaking any existing behaviour)

- on FilesProcessor.js I added two lambdas, one to create a list of all the altas definition files that will be created and another to exclude the current file from the array (an atlas definition must not reference itself as part of the multipack). I also added the corresponding checks for the new flag introduced on index.js

- on JsonHash.mst I added what I think is the correct syntax for an array of string in the meta object under the name `relatedMultiPacks`. I am not familiar with the other export templates so I didn't dare to modify them.

---

Please test this before merging because I couldn't find a way to test it due to my inexperience with javascript library programming.