### PR TITLE
updated jimp to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "@jvitela/mustache-wax": "^1.0.1",
-    "jimp": "^0.2.28",
+    "jimp": "^0.16.1",
     "maxrects-packer": "^2.5.0",
     "mustache": "^2.3.0",
     "tinify": "^1.5.0"


### PR DESCRIPTION
jimp is outdated and flagging warning from npm audit which looks bad.

according to jimp change log there is no breaking change and includes bug fixes
https://github.com/oliver-moran/jimp/blob/master/CHANGELOG.md