### PR TITLE
Handle scale for minium spritesheet

### DIFF
--- a/FilesProcessor.js
+++ b/FilesProcessor.js
@@ -21,9 +21,10 @@ class FilesProcessor {
                         });
 
                         if(packResult.length >= res.length) {
-                            let ix = 0;
+                            const suffix = options.suffix;
+                            let ix = options.suffixInitialValue;
                             for(let item of packResult) {
-                                let fName = options.textureName + (packResult.length > 1 ? "-" + ix : "");
+                                let fName = options.textureName + (packResult.length > 1 ? suffix + ix : "");
 
                                 FilesProcessor.processPackResultItem(fName, item, options, (files) => {
                                     resFiles = resFiles.concat(files);

--- a/PackProcessor.js
+++ b/PackProcessor.js
@@ -98,8 +98,8 @@ class PackProcessor {
             });
         }
 
-        let width = options.width || 0;
-        let height = options.height || 0;
+        let width = options.width / options.scale || 0;
+        let height = options.height / options.scale|| 0;
 
         if(!width) width = maxWidth;
         if(!height) height = maxHeight;

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ texturePacker(images, options, (files, error) => {
 # Available options
 
 * `textureName` - name of output files. Default: **pack-result**
+* `suffix` - the suffix used for multiple sprites. Default: **-**
+* `suffixInitialValue` - the initial value of the suffix. Default: **0**
 * `width` - max single texture width. Default: **2048**
 * `height` - max single texture height. Default: **2048**
 * `fixedSize` - fix texture size. Default: **false**

--- a/index.js
+++ b/index.js
@@ -32,6 +32,8 @@ function packAsync(images, options) {
     options = Object.assign({}, options);
 
     options.textureName = options.textureName === undefined ? "pack-result" : options.textureName;
+    options.suffix = options.suffix === undefined ? "-" : options.suffix;
+    options.suffixInitialValue = options.suffixInitialValue === undefined ? 0 : options.suffixInitialValue;
     options.width = options.width === undefined ? 2048 : options.width;
     options.height = options.height === undefined ? 2048 : options.height;
     options.powerOfTwo = !!options.powerOfTwo;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "@jvitela/mustache-wax": "^1.0.1",
-    "jimp": "^0.2.28",
+    "jimp": "^0.16.1",
     "maxrects-packer": "^2.5.0",
     "mustache": "^2.3.0",
     "tinify": "^1.5.0"


### PR DESCRIPTION
@odrick 

this will fix the issue mentioned #27 this will respect the use width and height option and will produce the smallest number of spritesheet at the scale the user sets.

Regard