### PR TITLE
add support for scale on output spritesheet to respect the width and …

### DIFF
--- a/PackProcessor.js
+++ b/PackProcessor.js
@@ -98,8 +98,8 @@ class PackProcessor {
             });
         }
 
-        let width = options.width || 0;
-        let height = options.height || 0;
+        let width = options.width / options.scale || 0;
+        let height = options.height / options.scale || 0;
 
         if(!width) width = maxWidth;
         if(!height) height = maxHeight;


### PR DESCRIPTION
…height option

@odrick 

this will fix the issue mentioned #27 this will respect the use width and height option and will produce the smallest number of spritesheet at the scale the user sets.

Regard