### PR TITLE
Fixes Phaser3.mt template.

### DIFF
--- a/exporters/Phaser3.mst
+++ b/exporters/Phaser3.mst
@@ -1,7 +1,7 @@
 {
 	"textures": [
 		{
-			"image": "{{^config.base64Export}}{{config.imageFile}}{{/config.base64Export}}{{#config.base64Export}}{{{config.base64Prefix}}}{{{config.imageData}}}{{/config.base64Export}}",
+			"image": "{{^config.base64Export}}{{config.imageName}}{{/config.base64Export}}{{#config.base64Export}}{{{config.base64Prefix}}}{{{config.imageData}}}{{/config.base64Export}}",
 			"format": "{{config.format}}",
 			"size": {
 				"w": {{config.imageWidth}},


### PR DESCRIPTION
The `"image"`field of the `"textures"` section should reference to `config.imageName` and not `config.imageFile`.