### PR TITLE
Fix strict mode error in `loadImage`

### DIFF
--- a/FilesProcessor.js
+++ b/FilesProcessor.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const { getPixelFormat, encodeTextureBuffer } = require("./utils/imageFormats");
 let PackProcessor = require("./PackProcessor");
 let TextureRenderer = require("./utils/TextureRenderer");

--- a/PackProcessor.js
+++ b/PackProcessor.js
@@ -1,3 +1,5 @@
+"use strict";
+
 let MaxRectsBinPack = require('./packers/MaxRectsBin');
 let OptimalPacker = require('./packers/OptimalPacker');
 let allPackers = require('./packers').list;

--- a/exporters/index.js
+++ b/exporters/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 let list = require("./list.json");
 let appInfo = require("../package.json");
 const { getBase64Prefix } = require("../utils/imageFormats");

--- a/filters/Filter.js
+++ b/filters/Filter.js
@@ -1,3 +1,5 @@
+"use strict";
+
 class Filter {
     constructor() {
     }

--- a/filters/Grayscale.js
+++ b/filters/Grayscale.js
@@ -1,3 +1,5 @@
+"use strict";
+
 let Filter = require('./Filter');
 
 class Grayscale extends Filter {

--- a/filters/Mask.js
+++ b/filters/Mask.js
@@ -1,3 +1,5 @@
+"use strict";
+
 let Filter = require('./Filter');
 
 class Mask extends Filter {

--- a/filters/index.js
+++ b/filters/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 let Filter = require('./Filter');
 let Mask = require('./Mask');
 let Grayscale = require('./Grayscale');

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function loadImage(file, files) {
 			files[image.name] = image;
 		})
 		.catch(e => {
-			console.error(getErrorDescription("Error reading " + file.path));
+			throw new Error(getErrorDescription("Error reading " + file.path + ": " + e.message));
 		});
 }
 

--- a/index.js
+++ b/index.js
@@ -20,8 +20,6 @@ function loadImage(file, files) {
 		.then(image => {
 			image.name = fixPath(file.path);
 			image._base64 = file.contents.toString("base64");
-			image.width = image.bitmap.width;
-			image.height = image.bitmap.height;
 			files[image.name] = image;
 		})
 		.catch(e => {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 let getPackerByType = require("./packers/index").getPackerByType;
 let getExporterByType = require("./exporters/index").getExporterByType;
 let getFilterByType = require("./filters").getFilterByType;

--- a/math/Rect.js
+++ b/math/Rect.js
@@ -1,3 +1,5 @@
+"use strict";
+
 class Rect {
     constructor(x=0, y=0, width=0, height=0) {
         this.x = x;

--- a/packers/MaxRectsBin.js
+++ b/packers/MaxRectsBin.js
@@ -1,3 +1,5 @@
+"use strict";
+
 let Packer = require("./Packer");
 let Rect = require("../math/Rect");
 

--- a/packers/MaxRectsPacker.js
+++ b/packers/MaxRectsPacker.js
@@ -1,3 +1,5 @@
+"use strict";
+
 let MaxRectsPackerEngine = require("maxrects-packer").MaxRectsPacker;
 let PACKING_LOGIC = require("maxrects-packer").PACKING_LOGIC;
 

--- a/packers/OptimalPacker.js
+++ b/packers/OptimalPacker.js
@@ -1,3 +1,5 @@
+"use strict";
+
 let Packer = require("./Packer");
 
 const METHOD = {

--- a/packers/Packer.js
+++ b/packers/Packer.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const METHOD = {
     Default: "Default"
 };

--- a/packers/index.js
+++ b/packers/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 let MaxRectsPacker = require("./MaxRectsPacker");
 let MaxRectsBin = require("./MaxRectsBin");
 let OptimalPacker = require("./OptimalPacker");

--- a/tests/strict-mode-width-height.test.js
+++ b/tests/strict-mode-width-height.test.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const sharp = require("sharp");
+
+const { packAsync } = require("../index");
+
+async function makeMinimalPng() {
+	return sharp(
+		Buffer.from([
+			255, 0, 0, 255,   0, 255, 0, 255,   0, 0, 255, 255,   255, 255, 0, 255,
+			255, 0, 0, 255,   0, 255, 0, 255,   0, 0, 255, 255,   255, 255, 0, 255,
+			255, 0, 0, 255,   0, 255, 0, 255,   0, 0, 255, 255,   255, 255, 0, 255,
+			255, 0, 0, 255,   0, 255, 0, 255,   0, 0, 255, 255,   255, 255, 0, 255,
+		]),
+		{ raw: { width: 4, height: 4, channels: 4 } }
+	)
+		.png()
+		.toBuffer();
+}
+
+describe("strict-mode width/height regression (issue #54)", () => {
+	it("packAsync resolves with non-empty frames for a single sprite", async () => {
+		const png = await makeMinimalPng();
+		const input = [{ path: "sprite.png", contents: png }];
+
+		const result = await packAsync(input, {
+			textureName: "test",
+			width: 64,
+			height: 64,
+			exporter: "JsonHash",
+			allowRotation: false,
+			allowTrim: false,
+		});
+
+		assert.ok(Array.isArray(result), "packAsync must resolve with an array");
+
+		const json = result.find((f) => f.name.endsWith(".json"));
+		assert.ok(json, "missing JSON metadata file");
+
+		const meta = JSON.parse(json.buffer.toString("utf8"));
+		assert.ok(
+			Object.keys(meta.frames).length > 0,
+			"frames must not be empty — image was silently dropped (issue #54)"
+		);
+	});
+});

--- a/utils/TextureRenderer.js
+++ b/utils/TextureRenderer.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const { Jimp, blitImage, getResizeStrategy } = require("./jimp");
 
 class TextureRenderer {

--- a/utils/Trimmer.js
+++ b/utils/Trimmer.js
@@ -1,3 +1,5 @@
+"use strict";
+
 class Trimmer {
 
     constructor() {

--- a/utils/imageFormats.js
+++ b/utils/imageFormats.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const path = require("path");
 const sharp = require("sharp");
 const { Jimp, JimpMime } = require("./jimp");

--- a/utils/jimp.js
+++ b/utils/jimp.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const { Jimp, JimpMime, ResizeStrategy } = require("jimp");
 
 /**


### PR DESCRIPTION
Enables strict mode everywhere to surface errors otherwise hidden in the test suite. Also improves the error handling for `loadImage` to prevent hanging indefinitely when errors happen. These two changes allowed the error to be reproduced in the test suite, which is then fixed by the last commit in the PR.

Fixes #54 